### PR TITLE
Make products by name filtering case insensitive

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,5 +12,5 @@ class Product < ApplicationRecord
   validates :units_in_stock, :units_on_order, :reorder_level, numericality: { less_than_or_equal_to: 32767, greater_than_or_equal_to: 0 }
 
   scope :category_id, -> (category) { where category: category }
-  scope :product_name, -> (product) { where("product_name LIKE ?", "%#{product}%")}
+  scope :product_name, -> (product) { where("lower(product_name) LIKE ?", "%#{product.downcase}%")}
 end


### PR DESCRIPTION
Zmieniłem filtr nazwy produktów tak, aby był niewrażliwy na wielkość liter. Boję się jednak, że to rozwiązanie jest podatne na atak SQL infection. Może Arel ma jakieś lepsze rozwiązania, które tutaj by znalazły zastosowanie?